### PR TITLE
Fix ta01 POST requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 /*******************************************************************************
- * Feel free to remove this comment block and all other comments after pulling. 
+ * Feel free to remove this comment block and all other comments after pulling.
  * They're for information purposes only.
- * 
+ *
  * This layout is provided to you for an easy and quick setup to either pull
  * or use to correct yours after working at least 1 hour on Team Activity 02.
  * Throughout the course, we'll be using Express.js for our view engines.
  * However, feel free to use pug or handlebars ('with extension hbs'). You will
  * need to make sure you install them beforehand according to the reading from
- * Udemy course. 
+ * Udemy course.
  * IMPORTANT: Make sure to run "npm install" in your root before "npm start"
  *******************************************************************************/
 // Our initial setup (package requires, port number setup)
@@ -21,24 +21,24 @@ const app = express();
 // Route setup. You can implement more in the future!
 const ta01Routes = require('./routes/ta01');
 const ta02Routes = require('./routes/ta02');
-const ta03Routes = require('./routes/ta03'); 
-const ta04Routes = require('./routes/ta04'); 
+const ta03Routes = require('./routes/ta03');
+const ta04Routes = require('./routes/ta04');
 
 app.use(express.static(path.join(__dirname, 'public')))
    .set('views', path.join(__dirname, 'views'))
    .set('view engine', 'ejs')
    // For view engine as Pug
-   //.set('view engine', 'pug') // For view engine as PUG. 
+   //.set('view engine', 'pug') // For view engine as PUG.
    // For view engine as hbs (Handlebars)
    //.engine('hbs', expressHbs({layoutsDir: 'views/layouts/', defaultLayout: 'main-layout', extname: 'hbs'})) // For handlebars
    //.set('view engine', 'hbs')
-   .use(bodyParser({extended: false})) // For parsing the body of a POST
    .use('/ta01', ta01Routes)
-   .use('/ta02', ta02Routes) 
-   .use('/ta03', ta03Routes) 
+   .use(bodyParser({extended: false})) // For parsing the body of a POST
+   .use('/ta02', ta02Routes)
+   .use('/ta03', ta03Routes)
    .use('/ta04', ta04Routes)
    .get('/', (req, res, next) => {
-     // This is the primary index, always handled last. 
+     // This is the primary index, always handled last.
      res.render('pages/index', {title: 'Welcome to my CSE341 repo', path: '/'});
     })
    .use((req, res, next) => {


### PR DESCRIPTION
Move `.use(bodyParser({extended: false}))` below `.use('/ta01', ta01Routes)` so form data can be parsed in the ta01 route file.
Fixes ta01 POST requests timing out.